### PR TITLE
docs: add PM2 process management setup and ecosystem config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,49 @@ npm start
 
 The production server runs on port `3099` by default and serves the UI from the built static files.
 
+### Running as a Background Service with PM2
+
+[PM2](https://pm2.keymetrics.io/) is a process manager for Node.js that keeps the gateway running in the background, restarts it on crashes, and can launch it automatically on system boot.
+
+**Install PM2 globally:**
+
+```bash
+npm install -g pm2
+```
+
+**Build, then start via the included ecosystem config:**
+
+```bash
+npm run build
+npm run pm2:start
+```
+
+The `ecosystem.config.cjs` file at the project root configures the process name, log file location, timestamps, and auto-restart behaviour. Logs are written to `logs/mcp-gateway.log` inside the project directory.
+
+**Other useful commands:**
+
+| Action       | npm script            | pm2 equivalent                     |
+| ------------ | --------------------- | ---------------------------------- |
+| Start        | `npm run pm2:start`   | `pm2 start ecosystem.config.cjs`   |
+| Stop         | `npm run pm2:stop`    | `pm2 stop ecosystem.config.cjs`    |
+| Restart      | `npm run pm2:restart` | `pm2 restart ecosystem.config.cjs` |
+| View logs    |                       | `pm2 logs mcp-gateway`             |
+| Process list |                       | `pm2 status`                       |
+
+
+**Start automatically on system boot:**
+
+After starting the process at least once, run:
+
+```bash
+pm2 save          # snapshot the current process list
+pm2 startup       # generate and register the startup script
+```
+
+`pm2 startup` will print a command to run (with `sudo`) — copy and execute it. After that, PM2 and the gateway will survive reboots automatically.
+
+> **Note:** The ecosystem config runs `npm start`, which requires a production build (`npm run build`) to exist first. Do not point PM2 at `npm run dev` for a persistent service — the dev server (Vite + tsx watch) is not suitable for long-running background operation.
+
 ## Configuration
 
 ### Environment Variables

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  apps: [
+    {
+      name: "mcp-gateway",
+      script: "npm",
+      args: "start",
+      cwd: __dirname,
+      log_file: "logs/mcp-gateway.log",
+      log_date_format: "YYYY-MM-DD HH:mm:ss Z",
+      merge_logs: true,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "500M",
+      env: {
+        NODE_ENV: "production",
+        PORT: 3099,
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
+    "pm2:start": "pm2 start ecosystem.config.cjs",
+    "pm2:stop": "pm2 stop ecosystem.config.cjs",
+    "pm2:restart": "pm2 restart ecosystem.config.cjs",
     "dev:server": "tsx watch src/server/index.ts",
     "dev:client": "vite",
     "build": "npm run build:client && npm run build:server",


### PR DESCRIPTION
## What?

Adds a suggested workflow for running the gateway as a persistent background service using [PM2](https://pm2.keymetrics.io/).

Might be useful to anyone else consuming this repo as it's a setup that works nicely for myself.

### How?

- **`ecosystem.config.cjs`** — declarative PM2 config (process name, log file with timestamps, auto-restart, memory limit). Uses `.cjs` extension because `package.json` declares `"type": "module"`.
- **`package.json`** — adds `pm2:start`, `pm2:stop`, `pm2:restart`, `pm2:logs`, and `pm2:status` scripts so users don't need to know pm2 CLI flags.
- **`README.md`** — new *Running as a Background Service with PM2* section under Getting Started, covering install, first-run, command reference table, and `pm2 startup` for boot persistence.

### Why `.cjs`?

The project sets `"type": "module"` in `package.json`, which means `.js` files are treated as ESM. PM2 ecosystem files use `module.exports`, so the file must be explicitly CommonJS — hence `.cjs`.
