### PR TITLE
:bug: Fix type error when merging process.env with config.env

### DIFF
--- a/src/server/gateway.ts
+++ b/src/server/gateway.ts
@@ -383,7 +383,9 @@ export class Gateway extends EventEmitter {
       command: config.command,
       args: config.args,
       cwd: expandedCwd,
-      env: config.env ? { ...process.env, ...config.env } : undefined,
+        env: config.env
+        ? ({ ...process.env, ...config.env } as Record<string, string>)
+        : undefined,
     });
 
     const client = new Client(


### PR DESCRIPTION
When I ran `npm run build I would hit this type error:

```sh
src/server/gateway.ts:386:7 - error TS2322: Type '{ [x: string]: string | undefined; TZ?: string | undefined; } | undefined' is not assignable to type 'Record<string, string> | undefined'.
  Type '{ [x: string]: string | undefined; TZ?: string | undefined; }' is not assignable to type 'Record<string, string>'.
    'string' index signatures are incompatible.
      Type 'string | undefined' is not assignable to type 'string'.
        Type 'undefined' is not assignable to type 'string'.

386       env: config.env ? { ...process.env, ...config.env } : undefined,
          ~~~

  node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.d.ts:19:5
    19     env?: Record<string, string>;
           ~~~
    The expected type comes from property 'env' which is declared here on type 'StdioServerParameters'


Found 1 error in src/server/gateway.ts:386
```

This type assertion should solve that